### PR TITLE
Use std::move to absorb front()

### DIFF
--- a/include/concurrent_queue.h
+++ b/include/concurrent_queue.h
@@ -80,7 +80,7 @@ class ConcurrentQueue {
                 return false;
             }
 
-            value = _queue.front();
+            value = std::move(_queue.front());
             _queue.pop();
             return true;
         }
@@ -92,7 +92,7 @@ class ConcurrentQueue {
                 _condition.wait(lock);
             }
 
-            value = _queue.front();
+            value = std::move(_queue.front());
             _queue.pop();
         }
 
@@ -110,7 +110,7 @@ class ConcurrentQueue {
                 }
             }
 
-            value = _queue.front();
+            value = std::move(_queue.front());
             _queue.pop();
             return true;
         }


### PR DESCRIPTION
I watched Amir Kirsh's presentation at CppCon 2021, and realized that using std::move() to absorb the front() element is more efficient.
**Understanding and Mastering C++'s Complexity - Amir Kirsh - CppCon 2021**
38:51
https://youtu.be/ECA-7erEJdU?t=2331

